### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,9 @@ image:
 tasks:
   - init: mvn -f src/pom.xml clean install
     command: mvn -f src/server-rm/pom.xml jetty:run
+
+ports:
+  - port: 8800
+  - port: 8801
+  - port: 8802
+  - port: 8803

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,12 @@ image:
 tasks:
   - init: mvn -f src/pom.xml clean install
     command: mvn -f src/server-rm/pom.xml jetty:run
+  - command: mvn -f src/server-cm/pom.xml jetty:run
+    openMode: split-right
+  - command: mvn -f src/server-am/pom.xml jetty:run
+    openMode: split-right
+  - command: mvn -f src/server-qm/pom.xml jetty:run
+    openMode: split-right
 
 ports:
   - port: 8800

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: mvn -f src/pom.xml clean install
+    command: mvn -f src/server-rm/pom.xml jetty:start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,13 +2,16 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: mvn -f src/pom.xml clean install
+  - init: mvn -f src/pom.xml clean install  && gp sync-done mvninstall
     command: mvn -f src/server-rm/pom.xml jetty:run
-  - command: mvn -f src/server-cm/pom.xml jetty:run
+  - init: gp sync-await mvninstall
+    command: mvn -f src/server-cm/pom.xml jetty:run
     openMode: split-right
-  - command: mvn -f src/server-am/pom.xml jetty:run
+  - init: gp sync-await mvninstall
+    command: mvn -f src/server-am/pom.xml jetty:run
     openMode: split-right
-  - command: mvn -f src/server-qm/pom.xml jetty:run
+  - init: gp sync-await mvninstall
+    command: mvn -f src/server-qm/pom.xml jetty:run
     openMode: split-right
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,4 +3,4 @@ image:
 
 tasks:
   - init: mvn -f src/pom.xml clean install
-    command: mvn -f src/server-rm/pom.xml jetty:start
+    command: mvn -f src/server-rm/pom.xml jetty:run

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+
 # OSLC 2020 Reference Implementation
 
 ![CI](https://github.com/oslc-op/refimpl/workflows/CI/badge.svg)
 [![](https://img.shields.io/badge/talk-discourse-lightgrey.svg)](https://forum.open-services.net/)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/oslc-op/refimpl)
 
 
 ## Intro


### PR DESCRIPTION
_This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click._

Whatever. Gitpod seems to be the fastest way for people new to Lyo to run the RefImpl servers without setting up anything on their machines. In circa 80 seconds you get this:

![Screenshot 2021-02-28 at 11 15 19](https://user-images.githubusercontent.com/64734/109415014-7e01fb80-79b6-11eb-8e8e-6176603688f6.jpg)

![Screenshot 2021-02-28 at 11 15 23](https://user-images.githubusercontent.com/64734/109415018-82c6af80-79b6-11eb-9d4d-d82a1b4300ea.jpg)

