### PR TITLE
Promote JDK 17 to non-experimental

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,11 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: ['8', '11', '16']
+        jdk: ['8', '11', '17']
         experimental: [false]
         include:
-          - jdk: '17-ea'
-            experimental: true
           - jdk: '18-ea'
             experimental: true
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rationale: JDK 17 is GA

https://openjdk.java.net/projects/jdk/17/