### PR TITLE
Improve integration tests

### DIFF
--- a/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/servlet/ServletListener.java
+++ b/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/servlet/ServletListener.java
@@ -28,6 +28,7 @@ import java.util.NoSuchElementException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +42,13 @@ import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import co.oslc.refimpl.rm.gen.RestDelegate;
 
 // Start of user code imports
+import org.apache.jena.sys.JenaSystem;
 // End of user code
 
 /**
  * During the initialization of this ServletListener, the base URI for the OSLC resources produced by this server is configured through the OSLC4J method setPublicURI().
  * <p>
- * See getConfigurationProperty() for the different alternatives to set this base URI. 
+ * See getConfigurationProperty() for the different alternatives to set this base URI.
  */
 public class ServletListener implements ServletContextListener  {
     private static final Logger logger = LoggerFactory.getLogger(ServletListener.class);
@@ -67,6 +69,7 @@ public class ServletListener implements ServletContextListener  {
         String servletName = "JAX-RS Servlet";
 
         // Start of user code contextInitialized_init
+        JenaSystem.init();
         // End of user code
 
         ServletContext servletContext = servletContextEvent.getServletContext();
@@ -94,7 +97,7 @@ public class ServletListener implements ServletContextListener  {
 
         // Establish connection to data backbone etc ...
         RestDelegate.contextInitializeServletListener(servletContextEvent);
-        
+
         // Start of user code contextInitialized_final
         // End of user code
     }
@@ -108,7 +111,7 @@ public class ServletListener implements ServletContextListener  {
         // Shutdown connections to data backbone etc...
         RestDelegate.contextDestroyServletListener(servletContextEvent);
 
-        
+
         // Start of user code contextDestroyed_final
         // End of user code
     }

--- a/src/server-rm/src/test/java/co/oslc/misc/OslcMatchers.java
+++ b/src/server-rm/src/test/java/co/oslc/misc/OslcMatchers.java
@@ -1,0 +1,30 @@
+package co.oslc.misc;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+
+import java.util.Locale;
+import java.util.Set;
+
+public class OslcMatchers {
+    public static Matcher<? super String> isRdf() {
+        return new BaseMatcher<>() {
+            Set<String> rdfTypes = Set.of("text/turtle", "application/rdf+xml", "application/ld+json",
+                "application/n-triples");
+
+            @Override
+            public boolean matches(Object actual) {
+                Assert.assertNotNull(actual);
+                String actualContentType = ((String) actual).toLowerCase(Locale.ROOT);
+                return rdfTypes.contains(actualContentType);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("RDF type matches");
+            }
+        };
+    }
+}

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
@@ -2,6 +2,7 @@ package co.oslc.refimpl.rm;
 
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
@@ -26,9 +27,8 @@ public class RequirementsIT {
 
     @Test
     public void testSvcProvHasServices() {
-        Response response = given()
+        Response response = givenOslcRequest()
                 .auth().basic("admin", "admin")
-                .accept("text/turtle;q=1.0, application/rdf+xml;q=0.9, application/ld+json;q=0.8, application/n-triples;q=0.5")
             .when()
                 .get("http://localhost:8800/services/serviceProviders/sp_single");
 
@@ -37,6 +37,12 @@ public class RequirementsIT {
             .statusCode(200)
             .contentType(isRdf())
             .body(hasCreationFactory(response.getContentType()));
+    }
+
+    private RequestSpecification givenOslcRequest() {
+        return given()
+            .accept("text/turtle;q=1.0, application/rdf+xml;q=0.9, application/ld+json;q=0.8, application/n-triples;q=0.5")
+            .header("OSLC-Core-Version", "3.0");
     }
 
 

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
@@ -1,0 +1,71 @@
+package co.oslc.refimpl.rm;
+
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
+import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static co.oslc.misc.OslcMatchers.isRdf;
+import static io.restassured.RestAssured.given;
+public class RequirementsIT {
+    private static final Logger log = LoggerFactory.getLogger(RequirementsIT.class);
+
+    @Test
+    public void testSvcProvHasServices() {
+        Response response = given()
+                .auth().basic("admin", "admin")
+                .accept("text/turtle;q=1.0, application/rdf+xml;q=0.9, application/ld+json;q=0.8, application/n-triples;q=0.5")
+            .when()
+                .get("http://localhost:8800/services/serviceProviders/sp_single");
+
+        response.then()
+            .assertThat()
+            .statusCode(200)
+            .contentType(isRdf())
+            .body(hasCreationFactory(response.getContentType()));
+    }
+
+
+    private Matcher<ValidatableResponse> hasCreationFactory(String contentType) {
+        return new BaseMatcher<>() {
+            @Override
+            public boolean matches(Object o) {
+                long t1 = System.nanoTime();
+                Model model = parseJenaModel((String) o, contentType);
+                long t2 = System.nanoTime();
+                ServiceProvider sp = JenaModelHelper.unmarshalSingle(model, ServiceProvider.class);
+                long t3 = System.nanoTime();
+                log.trace("Model parsing took {}ms, JMH took {}ms", TimeUnit.NANOSECONDS.toMillis(t2-t1),
+                    TimeUnit.NANOSECONDS.toMillis(t3-t2));
+                return Arrays.stream(sp.getServices()).anyMatch(service -> service.getCreationFactories().length > 0);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                // TODO: add
+            }
+        };
+    }
+
+    // TODO: refactor/extract
+    private static Model parseJenaModel(String value, String contentType) {
+        Model model = ModelFactory.createDefaultModel();
+        // TODO: consider passing the GET URI as a base
+        RDFDataMgr.read(model, new StringReader(value), null, RDFLanguages.contentTypeToLang(contentType));
+        return model;
+    }
+}

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
@@ -17,7 +17,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +81,8 @@ public class RequirementsIT {
     private static Model parseJenaModel(String value, String contentType) {
         Model model = ModelFactory.createDefaultModel();
         // TODO: consider passing the GET URI as a base
-        RDFDataMgr.read(model, new StringReader(value), null, RDFLanguages.contentTypeToLang(contentType));
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+        RDFDataMgr.read(model, new BufferedInputStream(inputStream), null, RDFLanguages.contentTypeToLang(contentType));
         return model;
     }
 }

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
@@ -46,7 +46,9 @@ public class RequirementsIT {
             .assertThat()
             .statusCode(200)
             .contentType(isRdf())
-            .body(hasCreationFactory(response.getContentType()));
+            .body(hasCreationFactory(response.getContentType()),
+                hasCreationFactory(response.getContentType()),
+                hasCreationFactory(response.getContentType()));
     }
 
     private RequestSpecification givenOslcRequest() {

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/RequirementsIT.java
@@ -7,6 +7,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.sys.JenaSystem;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.hamcrest.BaseMatcher;
@@ -24,6 +25,12 @@ import static co.oslc.misc.OslcMatchers.isRdf;
 import static io.restassured.RestAssured.given;
 public class RequirementsIT {
     private static final Logger log = LoggerFactory.getLogger(RequirementsIT.class);
+
+
+    static {
+        // to remove init from the perf timing
+        JenaSystem.init();
+    }
 
     @Test
     public void testSvcProvHasServices() {

--- a/src/server-rm/src/test/java/co/oslc/refimpl/rm/SpCatalogIT.java
+++ b/src/server-rm/src/test/java/co/oslc/refimpl/rm/SpCatalogIT.java
@@ -1,3 +1,5 @@
+package co.oslc.refimpl.rm;
+
 import static io.restassured.RestAssured.*;
 import static io.restassured.config.XmlConfig.xmlConfig;
 import static io.restassured.matcher.RestAssuredMatchers.*;


### PR DESCRIPTION
Add basic helpers for RestAssured and a check for CF endpoints in the SP response.

@jadelkhoury one thing that really starts to bother me is performance. I had no idea it got so  bad in recent times. And looks like it's the same both for Jena and Lyo (that's a warm sample after a few tries):

> Model parsing took 640ms, JMH took 487ms.

The request is a simple GET on http://localhost:8800/services/serviceProviders/sp_single .