### PR TITLE
Make JDK 18 non-experimental and build with JDK 19 Early Access

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,12 +21,9 @@ jobs:
         distribution: ['temurin', 'zulu', 'liberica', 'adopt-openj9', 'microsoft']
         experimental: [false]
         include:
-          - jdk: '15' # Zulu MTS
+          - jdk: '18'
             experimental: false
             distribution: zulu
-          - jdk: '18-ea'
-            distribution: zulu
-            experimental: true
           - jdk: '19-ea'
             distribution: zulu
             experimental: true


### PR DESCRIPTION
Also drop JDK 15 MTS

See https://inside.java/2022/03/22/the-arrival-of-java18/