### PR TITLE
Switch to Groovy 4.0

### DIFF
--- a/src/refimpl-tests/pom.xml
+++ b/src/refimpl-tests/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <groovy.version>3.0.9</groovy.version>
+    <groovy.version>4.0.1</groovy.version>
   </properties>
 
   <build>
@@ -93,7 +93,7 @@
     </dependency>
     <!-- Optional dependencies for using Spock -->
     <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
       <version>${groovy.version}</version>
     </dependency>


### PR DESCRIPTION
See https://groovy-lang.org/releasenotes/groovy-4.0.html

> Groovy 4.0 requires JDK16+ to build and JDK8 is the minimum version of the JRE that we support. Groovy has been tested on JDK versions 8 through 17.
