### PR TITLE
Add maven enforcer to ensure package versions match

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,9 @@ indent_size = 2
 [*.{java,jsp,xml}]
 # due to a problem in Acceleo
 trim_trailing_whitespace = false
+
+[**/pom.xml]
+# same as Acceleo
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,3 +41,39 @@ jobs:
             ${{ runner.os }}-${{ matrix.jdk }}_${{ matrix.distribution }}-maven-
       - name: Build with Maven
         run: mvn -B verify --file src/pom.xml
+
+  maven-enforcer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['17']
+        distribution: ['zulu']
+        experimental: [false]
+        # include:
+        #   - jdk: '21-ea'
+        #     distribution: zulu
+        #     experimental: true
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.jdk }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.jdk }}_${{ matrix.distribution }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.jdk }}_${{ matrix.distribution }}-maven-
+      - name: maven-enforcer-plugin chec
+        run: |
+          mvn -B install --file src/pom.xml
+          mvn -B verify --file src/server-am/pom.xml -Pstrict
+          mvn -B verify --file src/server-cm/pom.xml -Pstrict
+          mvn -B verify --file src/server-qm/pom.xml -Pstrict
+          mvn -B verify --file src/server-rm/pom.xml -Pstrict

--- a/src/server-am/pom.xml
+++ b/src/server-am/pom.xml
@@ -49,6 +49,62 @@
     </repositories>
     <!-- Start of user code pre_dependencies
     -->
+    <profiles>
+      <profile>
+        <id>strict</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                <execution>
+                  <id>enforce-maven</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireMavenVersion>
+                        <version>3.6.0</version>
+                      </requireMavenVersion>
+                      <requireJavaVersion>
+                        <version>11</version>
+                      </requireJavaVersion>
+                      <bannedDependencies>
+                        <excludes>
+                          <exclude>xerces</exclude>
+                          <exclude>xml-apis</exclude>
+                          <exclude>com.sun.xml.bind:jaxb-impl</exclude>
+
+                          <!-- https://github.com/eclipse/lyo/pull/220 -->
+                          <!--                    <exclude>log4j:log4j</exclude>-->
+                          <!--log4j v2 is not used, just for the future-->
+                          <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                        </excludes>
+                      </bannedDependencies>
+                      <banDuplicatePomDependencyVersions/>
+                      <requireUpperBoundDeps>
+                        <excludes>
+                          <!--jersey and jena via commons-compress-->
+                          <exclude>org.osgi:org.osgi.core</exclude>
+                        </excludes>
+                      </requireUpperBoundDeps>
+                      <reactorModuleConvergence>
+                        <message>The reactor is not valid</message>
+                        <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                      </reactorModuleConvergence>
+                    </rules>
+                    <fail>true</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
     <!-- End of user code
     -->
     <dependencies>
@@ -124,9 +180,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.5</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.8</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Lyo dependencies -->

--- a/src/server-cm/pom.xml
+++ b/src/server-cm/pom.xml
@@ -49,6 +49,62 @@
     </repositories>
     <!-- Start of user code pre_dependencies
     -->
+    <profiles>
+      <profile>
+        <id>strict</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                <execution>
+                  <id>enforce-maven</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireMavenVersion>
+                        <version>3.6.0</version>
+                      </requireMavenVersion>
+                      <requireJavaVersion>
+                        <version>11</version>
+                      </requireJavaVersion>
+                      <bannedDependencies>
+                        <excludes>
+                          <exclude>xerces</exclude>
+                          <exclude>xml-apis</exclude>
+                          <exclude>com.sun.xml.bind:jaxb-impl</exclude>
+
+                          <!-- https://github.com/eclipse/lyo/pull/220 -->
+                          <!--                    <exclude>log4j:log4j</exclude>-->
+                          <!--log4j v2 is not used, just for the future-->
+                          <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                        </excludes>
+                      </bannedDependencies>
+                      <banDuplicatePomDependencyVersions/>
+                      <requireUpperBoundDeps>
+                        <excludes>
+                          <!--jersey and jena via commons-compress-->
+                          <exclude>org.osgi:org.osgi.core</exclude>
+                        </excludes>
+                      </requireUpperBoundDeps>
+                      <reactorModuleConvergence>
+                        <message>The reactor is not valid</message>
+                        <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                      </reactorModuleConvergence>
+                    </rules>
+                    <fail>true</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
     <!-- End of user code
     -->
     <dependencies>
@@ -124,9 +180,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.5</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.8</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Lyo dependencies -->

--- a/src/server-qm/pom.xml
+++ b/src/server-qm/pom.xml
@@ -49,6 +49,62 @@
     </repositories>
     <!-- Start of user code pre_dependencies
     -->
+    <profiles>
+      <profile>
+        <id>strict</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                <execution>
+                  <id>enforce-maven</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireMavenVersion>
+                        <version>3.6.0</version>
+                      </requireMavenVersion>
+                      <requireJavaVersion>
+                        <version>11</version>
+                      </requireJavaVersion>
+                      <bannedDependencies>
+                        <excludes>
+                          <exclude>xerces</exclude>
+                          <exclude>xml-apis</exclude>
+                          <exclude>com.sun.xml.bind:jaxb-impl</exclude>
+
+                          <!-- https://github.com/eclipse/lyo/pull/220 -->
+                          <!--                    <exclude>log4j:log4j</exclude>-->
+                          <!--log4j v2 is not used, just for the future-->
+                          <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                        </excludes>
+                      </bannedDependencies>
+                      <banDuplicatePomDependencyVersions/>
+                      <requireUpperBoundDeps>
+                        <excludes>
+                          <!--jersey and jena via commons-compress-->
+                          <exclude>org.osgi:org.osgi.core</exclude>
+                        </excludes>
+                      </requireUpperBoundDeps>
+                      <reactorModuleConvergence>
+                        <message>The reactor is not valid</message>
+                        <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                      </reactorModuleConvergence>
+                    </rules>
+                    <fail>true</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
     <!-- End of user code
     -->
     <dependencies>
@@ -124,9 +180,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.5</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.8</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Lyo dependencies -->

--- a/src/server-rm/pom.xml
+++ b/src/server-rm/pom.xml
@@ -50,6 +50,62 @@
     </repositories>
     <!-- Start of user code pre_dependencies
     -->
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+            <plugins>
+                <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                        <requireMavenVersion>
+                            <version>3.6.0</version>
+                        </requireMavenVersion>
+                        <requireJavaVersion>
+                            <version>11</version>
+                        </requireJavaVersion>
+                        <bannedDependencies>
+                            <excludes>
+                            <exclude>xerces</exclude>
+                            <exclude>xml-apis</exclude>
+                            <exclude>com.sun.xml.bind:jaxb-impl</exclude>
+
+                            <!-- https://github.com/eclipse/lyo/pull/220 -->
+                            <!--                    <exclude>log4j:log4j</exclude>-->
+                            <!--log4j v2 is not used, just for the future-->
+                            <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                            </excludes>
+                        </bannedDependencies>
+                        <banDuplicatePomDependencyVersions/>
+                        <requireUpperBoundDeps>
+                            <excludes>
+                            <!--jersey and jena via commons-compress-->
+                            <exclude>org.osgi:org.osgi.core</exclude>
+                            </excludes>
+                        </requireUpperBoundDeps>
+                        <reactorModuleConvergence>
+                            <message>The reactor is not valid</message>
+                            <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                        </reactorModuleConvergence>
+                        </rules>
+                        <fail>true</fail>
+                    </configuration>
+                    </execution>
+                </executions>
+                </plugin>
+            </plugins>
+            </build>
+        </profile>
+    </profiles>
     <!-- End of user code
     -->
     <dependencies>
@@ -136,9 +192,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.5</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.8</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Lyo dependencies -->


### PR DESCRIPTION
This will help us with one thing: when Snyk or Dependabot open a PR that should obviously be applied on Lyo Designer MTLs and not here, **is it safe to change the version in the MTL** or could there be version issues?