### PR TITLE
fix dependency versions

### DIFF
--- a/src/server-qm/pom.xml
+++ b/src/server-qm/pom.xml
@@ -134,16 +134,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>1.2.5</version>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>2.6.1</version>
         </dependency>
-        
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>


### PR DESCRIPTION
To remove the many warnings such as the ones below, update 2 dependencies.
as usual, if this is ok, I will make the change to the generator, and update all 4 servers

[WARNING] javax.inject.Inject scanned from multiple locations: jar:file:///C:/Users/JadEl-khoury/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar!/javax/inject/Inject.class, jar:file:///C:/Users/JadEl-khoury/.m2/repository/org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1.jar!/javax/inject/Inject.class

[WARNING] org.apache.taglibs.standard.tei.Util scanned from multiple locations: jar:file:///C:/Users/JadEl-khoury/.m2/repository/org/apache/taglibs/taglibs-standard-impl/1.2.5/taglibs-standard-impl-1.2.5.jar!/org/apache/taglibs/standard/tei/Util.class, jar:file:///C:/Users/JadEl-khoury/.m2/repository/javax/servlet/jstl/1.2/jstl-1.2.jar!/org/apache/taglibs/standard/tei/Util.class