### PR TITLE
feat: return 400 for bad requests instead of 500

### DIFF
--- a/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/RestDelegate.java
+++ b/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/RestDelegate.java
@@ -239,7 +239,9 @@ public class RestDelegate {
     public Requirement createRequirement(HttpServletRequest httpServletRequest, final Requirement aResource, final String serviceProviderId)
     {
         Requirement newResource = null;
-        
+        if (aResource.getIdentifier() == null || aResource.getTitle() == null) {
+            throw new WebApplicationException("Identifier and title are mandatory", Response.Status.BAD_REQUEST);
+        }
         
         // Start of user code createRequirement
         final Map<String, Requirement> requirements = requirementsForSP(serviceProviderId);


### PR DESCRIPTION
When a user sends in a Requirement without a title or id, respond with 400 Bad Request instead of 500 Internal Server Error.

We should also consider if we shall stop requiring requirement ID because it's not mandatory according to the spec - only title is.