### PR TITLE
Make path to oslcOAuthStore.xml configurable via ENV var.

### DIFF
--- a/src/server-am/src/main/java/co/oslc/refimpl/am/gen/auth/AuthenticationApplication.java
+++ b/src/server-am/src/main/java/co/oslc/refimpl/am/gen/auth/AuthenticationApplication.java
@@ -76,7 +76,15 @@ public class AuthenticationApplication implements Application {
     private AuthenticationApplication() {
         // Start of user code constructor_init
         // End of user code
+        var AUTH_VAR = "OAUTH_STORE_FILE";
+        final Map<String, String> env = System.getenv();
         oslcConsumerStoreFilename= "./oslcOAuthStore.xml";
+        if (env.containsKey(AUTH_VAR)) {
+            oslcConsumerStoreFilename = env.get(AUTH_VAR);
+            log.debug("ENV variable '{}' found", AUTH_VAR);
+        } else {
+            log.debug("ENV variable '{}' not defined", AUTH_VAR);
+        }
         oauth1TokenToApplicationConnector = new LRUCache<String, String>(2000);
         // Start of user code constructor_finalize
         // End of user code

--- a/src/server-cm/src/main/java/co/oslc/refimpl/cm/gen/auth/AuthenticationApplication.java
+++ b/src/server-cm/src/main/java/co/oslc/refimpl/cm/gen/auth/AuthenticationApplication.java
@@ -76,7 +76,15 @@ public class AuthenticationApplication implements Application {
     private AuthenticationApplication() {
         // Start of user code constructor_init
         // End of user code
+        var AUTH_VAR = "OAUTH_STORE_FILE";
+        final Map<String, String> env = System.getenv();
         oslcConsumerStoreFilename= "./oslcOAuthStore.xml";
+        if (env.containsKey(AUTH_VAR)) {
+            oslcConsumerStoreFilename = env.get(AUTH_VAR);
+            log.debug("ENV variable '{}' found", AUTH_VAR);
+        } else {
+            log.debug("ENV variable '{}' not defined", AUTH_VAR);
+        }
         oauth1TokenToApplicationConnector = new LRUCache<String, String>(2000);
         // Start of user code constructor_finalize
         // End of user code

--- a/src/server-qm/src/main/java/co/oslc/refimpl/qm/gen/auth/AuthenticationApplication.java
+++ b/src/server-qm/src/main/java/co/oslc/refimpl/qm/gen/auth/AuthenticationApplication.java
@@ -76,7 +76,15 @@ public class AuthenticationApplication implements Application {
     private AuthenticationApplication() {
         // Start of user code constructor_init
         // End of user code
+        var AUTH_VAR = "OAUTH_STORE_FILE";
+        final Map<String, String> env = System.getenv();
         oslcConsumerStoreFilename= "./oslcOAuthStore.xml";
+        if (env.containsKey(AUTH_VAR)) {
+            oslcConsumerStoreFilename = env.get(AUTH_VAR);
+            log.debug("ENV variable '{}' found", AUTH_VAR);
+        } else {
+            log.debug("ENV variable '{}' not defined", AUTH_VAR);
+        }
         oauth1TokenToApplicationConnector = new LRUCache<String, String>(2000);
         // Start of user code constructor_finalize
         // End of user code

--- a/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/auth/AuthenticationApplication.java
+++ b/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/auth/AuthenticationApplication.java
@@ -76,7 +76,15 @@ public class AuthenticationApplication implements Application {
     private AuthenticationApplication() {
         // Start of user code constructor_init
         // End of user code
+        var AUTH_VAR = "OAUTH_STORE_FILE";
+        final Map<String, String> env = System.getenv();
         oslcConsumerStoreFilename= "./oslcOAuthStore.xml";
+        if (env.containsKey(AUTH_VAR)) {
+            oslcConsumerStoreFilename = env.get(AUTH_VAR);
+            log.debug("ENV variable '{}' found", AUTH_VAR);
+        } else {
+            log.debug("ENV variable '{}' not defined", AUTH_VAR);
+        }
         oauth1TokenToApplicationConnector = new LRUCache<String, String>(2000);
         // Start of user code constructor_finalize
         // End of user code

--- a/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/auth/AuthenticationApplication.java
+++ b/src/server-rm/src/main/java/co/oslc/refimpl/rm/gen/auth/AuthenticationApplication.java
@@ -78,7 +78,7 @@ public class AuthenticationApplication implements Application {
         // End of user code
         var AUTH_VAR = "OAUTH_STORE_FILE";
         final Map<String, String> env = System.getenv();
-        oslcConsumerStoreFilename= "./oslcOAuthStore.xml";
+        oslcConsumerStoreFilename = "./oslcOAuthStore.xml";
         if (env.containsKey(AUTH_VAR)) {
             oslcConsumerStoreFilename = env.get(AUTH_VAR);
             log.debug("ENV variable '{}' found", AUTH_VAR);


### PR DESCRIPTION
as suggested in ticket #497

Each of the refimpl services contains its own 'AuthenticationApplication' class with a hard coded relative path to the oslcOAuthStore.xml file.

to improve the ability to map this file to a docker volume, enabling one to more easily set provisional to false for entries in the file.
I suggest you make it configurable with an environment variable.

closes #497

