### PR TITLE
fix(am): implement ResourceSelector to return filtered resources

### DIFF
--- a/src/refimpl-tests/pom.xml
+++ b/src/refimpl-tests/pom.xml
@@ -68,6 +68,13 @@
       <version>1.61.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- REST Assured -->
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>5.5.5</version>
+      <scope>test</scope>
+    </dependency>
     <!-- JUnit 5 -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/refimpl-tests/pom.xml
+++ b/src/refimpl-tests/pom.xml
@@ -75,6 +75,12 @@
       <version>5.5.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>2.0.18</version>
+      <scope>test</scope>
+    </dependency>
     <!-- JUnit 5 -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
+++ b/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
@@ -52,6 +52,7 @@ public class AmResourceSelectorTest {
         int    port = environment.getServicePort(AM_SVC, AM_PORT);
         RestAssured.baseURI = "http://" + host;
         RestAssured.port    = port;
+        RestAssured.authentication = RestAssured.preemptive().basic("admin", "admin");
 
         // Use a unique identifier so the test is isolated across runs.
         uniqueId = "selector-test-" + UUID.randomUUID().toString().substring(0, 8);

--- a/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
+++ b/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
@@ -1,0 +1,140 @@
+package co.oslc.refimpl.tests;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Acceptance tests for the AM server's Resource Selection dialog (issue #499).
+ *
+ * Verifies that:
+ *  1. A resource POSTed to the creation factory is queryable via the selector.
+ *  2. Searching by a matching term returns a non-empty result set.
+ *  3. Searching by a non-matching term returns an empty result set.
+ */
+@Testcontainers
+public class AmResourceSelectorTest {
+
+    static final String AM_SVC = "server-am";
+    static final int    AM_PORT = 8080;
+
+    /** Base path for the AM service-1 resources endpoints. */
+    static final String RESOURCES_BASE = "/services/service1/resources";
+
+    @Container
+    public static ComposeContainer environment =
+            new ComposeContainer(new File("src/test/resources/docker-compose.yml"))
+                    .withExposedService(AM_SVC, AM_PORT,
+                            Wait.forLogMessage(".*main: Started oejs.Server@.*", 1)
+                                    .withStartupTimeout(Duration.ofSeconds(120)))
+                    .withLocalCompose(true);
+
+    /** Unique identifier embedded in the resource created during this test run. */
+    static String uniqueId;
+
+    @BeforeAll
+    static void setUp() {
+        String host = environment.getServiceHost(AM_SVC, AM_PORT);
+        int    port = environment.getServicePort(AM_SVC, AM_PORT);
+        RestAssured.baseURI = "http://" + host;
+        RestAssured.port    = port;
+
+        // Use a unique identifier so the test is isolated across runs.
+        uniqueId = "selector-test-" + UUID.randomUUID().toString().substring(0, 8);
+
+        // POST a new resource to the AM creation factory.
+        // The payload is a minimal Turtle representation of an AM Resource.
+        String turtle =
+                "@prefix oslc_am: <http://open-services.net/ns/am#> .\n" +
+                "@prefix dcterms: <http://purl.org/dc/terms/> .\n" +
+                "@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+                "<> a oslc_am:Resource ;\n" +
+                "   dcterms:identifier \"" + uniqueId + "\" ;\n" +
+                "   dcterms:title      \"Selector test resource " + uniqueId + "\" .\n";
+
+        given()
+            .contentType("text/turtle")
+            .accept("text/turtle")
+            .body(turtle)
+        .when()
+            .post(RESOURCES_BASE + "/create")
+        .then()
+            .statusCode(201);
+    }
+
+    /**
+     * Querying the selector with {@code terms} equal to the unique identifier must
+     * return a JSON object whose {@code oslc:results} array contains at least one
+     * entry whose {@code rdf:resource} is non-empty (the previously created resource).
+     */
+    @Test
+    void selectorReturnsResourceWhenTermMatches() {
+        given()
+            .accept(ContentType.JSON)
+            .queryParam("terms", uniqueId)
+        .when()
+            .get(RESOURCES_BASE + "/selector")
+        .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("'oslc:results'", not(empty()))
+            .body("'oslc:results'[0].'rdf:resource'", not(emptyOrNullString()));
+    }
+
+    /**
+     * Querying the selector with {@code terms} that cannot match any stored resource
+     * must return a JSON object with an empty {@code oslc:results} array (not an
+     * error).
+     */
+    @Test
+    void selectorReturnsEmptyResultsForNonMatchingTerm() {
+        String noMatchTerm = "zzz-no-match-" + UUID.randomUUID();
+
+        given()
+            .accept(ContentType.JSON)
+            .queryParam("terms", noMatchTerm)
+        .when()
+            .get(RESOURCES_BASE + "/selector")
+        .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("'oslc:results'", empty());
+    }
+
+    /**
+     * Querying with {@code terms=""} (empty string) must also return the created
+     * resource (the selector shows all resources when no filter is applied).
+     */
+    @Test
+    void selectorReturnsAllResourcesWhenTermsIsEmpty() {
+        Response response = given()
+            .accept(ContentType.JSON)
+            .queryParam("terms", "")
+        .when()
+            .get(RESOURCES_BASE + "/selector")
+        .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("'oslc:results'", not(empty()))
+            .extract().response();
+
+        // The unique resource we created must appear in the full list.
+        String body = response.asString();
+        assertTrue(body.contains(uniqueId),
+                "Selector should include the previously created resource when terms is empty");
+    }
+}

--- a/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
+++ b/src/refimpl-tests/src/test/java/co/oslc/refimpl/tests/AmResourceSelectorTest.java
@@ -58,13 +58,14 @@ public class AmResourceSelectorTest {
 
         // POST a new resource to the AM creation factory.
         // The payload is a minimal Turtle representation of an AM Resource.
-        String turtle =
-                "@prefix oslc_am: <http://open-services.net/ns/am#> .\n" +
-                "@prefix dcterms: <http://purl.org/dc/terms/> .\n" +
-                "@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
-                "<> a oslc_am:Resource ;\n" +
-                "   dcterms:identifier \"" + uniqueId + "\" ;\n" +
-                "   dcterms:title      \"Selector test resource " + uniqueId + "\" .\n";
+        String turtle = """
+                @prefix oslc_am: <http://open-services.net/ns/am#> .
+                @prefix dcterms: <http://purl.org/dc/terms/> .
+                @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                <> a oslc_am:Resource ;
+                   dcterms:identifier "%s" ;
+                   dcterms:title      "Selector test resource %s" .
+                """.formatted(uniqueId, uniqueId);
 
         given()
             .contentType("text/turtle")

--- a/src/refimpl-tests/src/test/resources/simplelogger.properties
+++ b/src/refimpl-tests/src/test/resources/simplelogger.properties
@@ -1,0 +1,6 @@
+# SLF4J SimpleLogger configuration for refimpl-tests
+org.slf4j.simpleLogger.defaultLogLevel=warn
+org.slf4j.simpleLogger.log.co.oslc.refimpl=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=false

--- a/src/server-am/src/main/java/co/oslc/refimpl/am/gen/RestDelegate.java
+++ b/src/server-am/src/main/java/co/oslc/refimpl/am/gen/RestDelegate.java
@@ -112,11 +112,24 @@ public class RestDelegate {
     }
     public List<Resource> ResourceSelector(HttpServletRequest httpServletRequest, String terms)
     {
-        List<Resource> resources = null;
+        List<Resource> resources = new ArrayList<>();
         
         
         // Start of user code ResourceSelector
-        // TODO Implement code to return a set of resources, based on search criteria
+        List<Resource> allResources = resourceRepository.fetchResourcesForSP(SP_DEFAULT);
+        if (allResources != null) {
+            if (terms == null || terms.isEmpty()) {
+                resources.addAll(allResources);
+            } else {
+                String lowerTerms = terms.toLowerCase();
+                for (Resource resource : allResources) {
+                    if ((resource.getIdentifier() != null && resource.getIdentifier().toLowerCase().contains(lowerTerms)) ||
+                        resource.toString().toLowerCase().contains(lowerTerms)) {
+                        resources.add(resource);
+                    }
+                }
+            }
+        }
         // End of user code
         return resources;
     }

--- a/src/server-am/src/main/java/co/oslc/refimpl/am/gen/RestDelegate.java
+++ b/src/server-am/src/main/java/co/oslc/refimpl/am/gen/RestDelegate.java
@@ -112,10 +112,11 @@ public class RestDelegate {
     }
     public List<Resource> ResourceSelector(HttpServletRequest httpServletRequest, String terms)
     {
-        List<Resource> resources = new ArrayList<>();
+        List<Resource> resources = null;
         
         
         // Start of user code ResourceSelector
+        resources = new ArrayList<>();
         List<Resource> allResources = resourceRepository.fetchResourcesForSP(SP_DEFAULT);
         if (allResources != null) {
             if (terms == null || terms.isEmpty()) {


### PR DESCRIPTION
## Summary

Fixes #499 — the AM Resource Selection dialog was returning nothing because `ResourceSelector` in `RestDelegate` always returned `null`.

## Changes

In `co.oslc.refimpl.am.gen.RestDelegate`:

- When no `terms` are provided, return all resources (shows the full list in the dialog before the user types)
- When `terms` are provided, filter case-insensitively against `getIdentifier()` and `toString()`

The filtering logic is based on the suggestion in issue #499.