### PR TITLE
ci: grant rebase workflow write access

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: peter-evans/rebase@v4
+      - uses: peter-evans/rebase@e4945786f7ca41fe6e101cead4395f5489593943 #v4.0.0
         with:
           exclude-labels: |
             no-rebase

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   rebase:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: peter-evans/rebase@v4
         with:


### PR DESCRIPTION
## Summary
- grant the scheduled/manual rebase workflow explicit contents write permission
- declare pull request read permission for PR discovery

## Validation
- `git diff --check`
- no Maven tests run; workflow-only change